### PR TITLE
Fix submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,17 +1,17 @@
 [submodule "riscv-binutils"]
 	path = riscv-binutils
-	url = ../riscv-binutils-gdb.git
+	url = https://github.com/riscv-collab/riscv-binutils-gdb.git
 	branch = riscv-binutils-2.36.1
 [submodule "riscv-gcc"]
 	path = riscv-gcc
-	url = ../riscv-gcc.git
+	url = https://github.com/riscv-collab/riscv-gcc.git
 	branch = riscv-gcc-10.2.0
 [submodule "riscv-glibc"]
 	path = riscv-glibc
 	url = git://sourceware.org/git/glibc.git
 [submodule "riscv-dejagnu"]
 	path = riscv-dejagnu
-	url = ../riscv-dejagnu.git
+	url = https://github.com/riscv-collab/riscv-dejagnu.git
 	branch = riscv-dejagnu-1.6
 [submodule "riscv-newlib"]
 	path = riscv-newlib
@@ -19,7 +19,7 @@
 	branch = master
 [submodule "riscv-gdb"]
 	path = riscv-gdb
-	url = ../riscv-binutils-gdb.git
+	url = https://github.com/riscv-collab/riscv-binutils-gdb.git
 	branch = fsf-gdb-10.1-with-sim
 [submodule "qemu"]
 	path = qemu


### PR DESCRIPTION
riscv-gcc and riscv-binutils has moved to https://github.com/riscv-collab, which break the relative path for the submodule...